### PR TITLE
Fix: Improve message when domain is missing in --add command

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -146,6 +146,10 @@ addhost() {
       --domain|-d)
         shift
         domain="$1"
+        [[ -z "$1" ]] && {
+          msg error MISSING_ARGUMENT >&2
+          return 1
+        }
         ;;
       --ip|-i)
         shift

--- a/msg/messages.json
+++ b/msg/messages.json
@@ -1,7 +1,7 @@
 {
     "error" :{
       "UNKNOWN_ACTION": "❌ Unknown action: %s\nUse -h or --help for usage.",
-      "MISSING_ARGUMENT":"❌ Missing domain after --domain",
+      "MISSING_ARGUMENT":"❌ Missing domain after --add",
       "INVALID_IP": "❌ Invalid IP Address: '%s'",
       "INVALID_DOMAIN": "❌ Invalid domain: %s",
       "DOMAIN_NOT_FOUND": "❌ Domain: '%s' not found",


### PR DESCRIPTION
This PR improves the error handling for the --add command when no domain argument is provided.

## **What’s changed**

- Added a validation inside the addhost() function to check if the domain argument is missing.
- Replaced the misleading error message "Invalid domain:" with a more accurate one:

```bash
❌ Missing domain after --domain|-d
```

- The new message is stored in msg/messages.json under the key "MISSING_ARGUMENT ".
- Updated the script to use the msg error MISSING_ARGUMENT call.

## **Benefits**

- Provides more precise and user-friendly feedback.
- Keeps message handling consistent and centralized.
- Maintains alignment with CLI UX conventions and prepares for future i18n support.